### PR TITLE
fix broken download links for flash download tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 
 #### Windows
-Windows can use Espressif Flash Download Tools([Download](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.4.rar)) (Erase first)：
+Windows can use Espressif Flash Download Tools([Download](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.5_0.zip)) (Erase first)：
   ![image](docs/img/windows_esptool.png) 
 
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,7 +46,7 @@
 
 
 #### Windows烧录
-Windows使用Espressif提供Flash Download Tools工具烧录([点击下载](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.4.rar))，设置如下(先擦除再烧录)：
+Windows使用Espressif提供Flash Download Tools工具烧录([点击下载](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.5_0.zip))，设置如下(先擦除再烧录)：
   ![image](docs/img/windows_esptool.png) 
 
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -46,7 +46,7 @@
 
 
 #### Windows
-WindowsではEspressif Flash Download Toolsが使えます([ダウンロード](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.4.rar)) (先にEraseを実行してください)：
+WindowsではEspressif Flash Download Toolsが使えます([ダウンロード](https://www.espressif.com/sites/default/files/tools/flash_download_tools_v3.6.5_0.zip)) (先にEraseを実行してください)：
   ![image](docs/img/windows_esptool.png)
 
 


### PR DESCRIPTION
A new version of the flash download tool was released, so the link was broken.

https://www.espressif.com/en/support/download/other-tools?keys=&field_type_tid%5B%5D=13